### PR TITLE
[composer] phpunit/phpunit 5.xをdevでrequire

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
 
 env:
-  - SYMFONY_VERSION=2.5.*
-  - SYMFONY_VERSION=2.6.*
   - SYMFONY_VERSION=2.7.*
   - SYMFONY_VERSION=2.8.*
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - SYMFONY_VERSION=2.5.*
   - SYMFONY_VERSION=2.6.*
   - SYMFONY_VERSION=2.7.*
+  - SYMFONY_VERSION=2.8.*
 
 before_script:
   - composer require symfony/framework-bundle:${SYMFONY_VERSION} symfony/http-kernel:${SYMFONY_VERSION} --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "twig/twig": "~1.15"
     },
     "require-dev": {
-        "symfony/browser-kit": "~2.5"
+        "symfony/browser-kit": "~2.5",
+        "phpunit/phpunit": "~5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
※このバンドルはほぼメンテしてませんが、Lisketのdeprecation warning消去に必要な範囲で修正しています。

バンドル単体でテストが動かなかったためphpunit/phpunitを入れました。