### PR TITLE
テスト環境の更新、Symfony2.8対応

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
 
 env:
-  - SYMFONY_VERSION=2.5.*
-  - SYMFONY_VERSION=2.6.*
   - SYMFONY_VERSION=2.7.*
   - SYMFONY_VERSION=2.8.*
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 php:
   - 5.6
+  - 7.0
+  - 7.1
 
 env:
   - SYMFONY_VERSION=2.7.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - SYMFONY_VERSION=2.5.*
   - SYMFONY_VERSION=2.6.*
   - SYMFONY_VERSION=2.7.*
+  - SYMFONY_VERSION=2.8.*
 
 before_script:
   - composer require symfony/framework-bundle:${SYMFONY_VERSION} symfony/http-kernel:${SYMFONY_VERSION} --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "twig/twig": "~1.15"
     },
     "require-dev": {
-        "symfony/browser-kit": "~2.5"
+        "symfony/browser-kit": "~2.5",
+        "phpunit/phpunit": "~5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -2,12 +2,12 @@ services:
   quartet_webpay_client:
     class: WebPay\WebPay
     arguments:
-      - %quartet_webpay.api_secret%
-      - %quartet_webpay.api_base%
+      - "%quartet_webpay.api_secret%"
+      - "%quartet_webpay.api_base%"
 
   quartet_webpay.accessor:
     abstract: true
-    factory: [@quartet_webpay_client, __get]
+    factory: ["@quartet_webpay_client", __get]
 
   quartet_webpay.customers:
     parent: quartet_webpay.accessor
@@ -42,6 +42,6 @@ services:
   quartet_webpay.twig_extension:
     class: Quartet\Bundle\WebPayBundle\Twig\Extension\WebPayExtension
     arguments:
-      - %quartet_webpay.test%
+      - "%quartet_webpay.test%"
     tags:
       - { name: twig.extension }


### PR DESCRIPTION
※現在使われておらず、ほぼメンテしていませんが、Lisketのdeprecation警告を消すために必要な範囲で修正を行っています。

- phpunitをcomposerの依存に入れる
- 古いPHPバージョンでテストしない
- 古いSymfonyバージョンでテストしない
- 新しいPHPバージョンでテストする
- 新しいSymfonyバージョンでテストする
- yml上の参照を引用符で囲む